### PR TITLE
Fix API tests and dependencies

### DIFF
--- a/app/api/v1/chat.py
+++ b/app/api/v1/chat.py
@@ -19,7 +19,6 @@ def get_latest_journal(db: Session, user: models.User) -> str:
         db=db,
         owner_id=user.id,
         limit=1,
-        order_by="created_at desc"  # <-- Tambahkan baris ini
     )
     return journals[0].content if journals else ""
 
@@ -106,3 +105,39 @@ async def handle_chat_message(
     )
 
     return ai_message_db
+
+
+@router.patch("/{chat_id}/flag", response_model=schemas.chat.ChatMessage)
+def flag_chat_message(
+    *,
+    chat_id: int,
+    flag: schemas.chat.ChatFlagUpdate,
+    db: Session = Depends(dependencies.get_db),
+    current_user: models.User = Depends(dependencies.get_current_user),
+):
+    msg = crud.chat_message.set_flag(
+        db=db,
+        id=chat_id,
+        owner_id=current_user.id,
+        flag=flag.flag,
+    )
+    if not msg:
+        raise HTTPException(status_code=404, detail="Message not found")
+    return msg
+
+
+@router.delete("/{chat_id}", response_model=schemas.chat.ChatMessage)
+def delete_chat_message(
+    *,
+    chat_id: int,
+    db: Session = Depends(dependencies.get_db),
+    current_user: models.User = Depends(dependencies.get_current_user),
+):
+    msg = crud.chat_message.remove(
+        db=db,
+        id=chat_id,
+        owner_id=current_user.id,
+    )
+    if not msg:
+        raise HTTPException(status_code=404, detail="Message not found")
+    return msg

--- a/app/services/planner_service.py
+++ b/app/services/planner_service.py
@@ -10,7 +10,7 @@ from app.schemas.plan import CommunicationTechnique, ConversationPlan
 from app.models.user_profile import UserProfile  # pastikan path ini valid
 
 class PlannerService:
-    def __init__(self, settings: Settings = settings):
+    def __init__(self, settings: Settings = Depends(lambda: settings)):
         self.settings = settings
         self.api_base_url = "https://openrouter.ai/api/v1"
         self.log = structlog.get_logger(__name__)
@@ -43,6 +43,7 @@ class PlannerService:
             chat_history: List[str],
             latest_journal: str,
             user_profile: Optional[UserProfile],
+            emotion_label: str,
     ) -> ConversationPlan:
         self.log.info("planning_conversation", user_message=user_message)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 fastapi
 SQLAlchemy
-pydantic
+pydantic>=2.7.0
 pydantic-settings
 passlib[bcrypt]
 python-jose[cryptography]
@@ -15,7 +15,8 @@ email-validator
 pytest-asyncio
 
 # Tambahan untuk Produksi & Task Queue
-+ gunicorn
-+ psycopg2-binary
-+ celery
-+ redis
+gunicorn
+psycopg2-binary
+celery
+redis
+alembic

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import sessionmaker
 from app.main import app
 from app.dependencies import get_db, get_current_user
 from app.db.base_class import Base
+from app import models
 from app.models.user import User
 
 @pytest.fixture

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -21,7 +21,7 @@ def test_chat_flow_success(client):
     client_app, session_local = client
 
     class DummyPlanner:
-        async def get_plan(self, user_message, chat_history, latest_journal, user_profile):
+        async def get_plan(self, user_message, chat_history, latest_journal, user_profile, emotion_label):
             # Pastikan user_profile adalah objek yang benar atau None
             assert user_profile is None or isinstance(user_profile, UserProfile)
             return ConversationPlan(technique=CommunicationTechnique.INFORMATION)

--- a/tests/test_openrouter_credentials.py
+++ b/tests/test_openrouter_credentials.py
@@ -20,7 +20,7 @@ async def test_services_handle_invalid_credentials(monkeypatch, api_key):
     monkeypatch.setattr(PlannerService, "_call_openrouter", raise_error)
     monkeypatch.setattr(GeneratorService, "_call_openrouter", raise_error)
 
-    plan = await planner.get_plan("hi", [], "", "neutral")
+    plan = await planner.get_plan("hi", [], "", None, "neutral")
     assert plan.technique == CommunicationTechnique.UNKNOWN
 
     result = await generator.generate_response(plan, [], None)

--- a/tests/test_planner_service.py
+++ b/tests/test_planner_service.py
@@ -13,6 +13,6 @@ async def test_get_plan_accepts_four_args(monkeypatch):
 
     monkeypatch.setattr(PlannerService, "_call_openrouter", fake_call)
 
-    plan = await planner.get_plan("hello", ["hi"], "", None)
+    plan = await planner.get_plan("hello", ["hi"], "", None, "neutral")
     assert plan.technique == CommunicationTechnique.INFORMATION
 


### PR DESCRIPTION
## Summary
- correct `PlannerService` dependency injection and update signature
- implement flag and delete endpoints for chat messages
- fix test fixtures and update tests for new planner API
- update requirements with pinned versions and alembic

## Testing
- `pip install --use-deprecated=legacy-resolver -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3ce82cc88324b2aa7dc24be3ef2d